### PR TITLE
Feature/get config from separate array

### DIFF
--- a/src/WeChatDriver.php
+++ b/src/WeChatDriver.php
@@ -31,6 +31,7 @@ class WeChatDriver extends HttpDriver implements VerifiesService
         }
         $this->payload = $request->request->all();
         $this->event = Collection::make($data);
+        $this->config = Collection::make($this->config->get('wechat'));
     }
 
     /**
@@ -92,7 +93,7 @@ class WeChatDriver extends HttpDriver implements VerifiesService
      */
     protected function getAccessToken()
     {
-        $response = $this->http->post('https://api.wechat.com/cgi-bin/token?grant_type=client_credential&appid='.$this->config->get('wechat_app_id').'&secret='.$this->config->get('wechat_app_key'),
+        $response = $this->http->post('https://api.wechat.com/cgi-bin/token?grant_type=client_credential&appid='.$this->config->get('app_id').'&secret='.$this->config->get('app_key'),
             [], []);
         $responseData = json_decode($response->getContent());
 
@@ -161,7 +162,7 @@ class WeChatDriver extends HttpDriver implements VerifiesService
      */
     public function isConfigured()
     {
-        return ! is_null($this->config->get('wechat_app_id')) && ! is_null($this->config->get('wechat_app_key'));
+        return ! is_null($this->config->get('app_id')) && ! is_null($this->config->get('app_key'));
     }
 
     /**

--- a/tests/WeChatDriverTest.php
+++ b/tests/WeChatDriverTest.php
@@ -125,16 +125,13 @@ class WeChatDriverTest extends PHPUnit_Framework_TestCase
 </xml>';
 
         $html = m::mock(Curl::class);
-        $html->shouldReceive('post')
-            ->once()
-            ->with('https://api.wechat.com/cgi-bin/token?grant_type=client_credential&appid=WECHAT-APP-ID&secret=WECHAT-APP-KEY', [], [])
-            ->andReturn(new Response(json_encode([
-                'access_token' => 'SECRET_TOKEN',
-            ])));
+        $html->shouldReceive('post')->once()->with('https://api.wechat.com/cgi-bin/token?grant_type=client_credential&appid=WECHAT-APP-ID&secret=WECHAT-APP-KEY',
+            [], [])->andReturn(new Response(json_encode([
+            'access_token' => 'SECRET_TOKEN',
+        ])));
 
-        $html->shouldReceive('post')
-            ->once()
-            ->with('https://api.wechat.com/cgi-bin/message/custom/send?access_token=SECRET_TOKEN', [], [
+        $html->shouldReceive('post')->once()->with('https://api.wechat.com/cgi-bin/message/custom/send?access_token=SECRET_TOKEN',
+            [], [
                 'touser' => 'from_user_name',
                 'msgtype' => 'text',
                 'text' => [
@@ -146,8 +143,10 @@ class WeChatDriverTest extends PHPUnit_Framework_TestCase
         $request->shouldReceive('getContent')->andReturn($xmlData);
 
         $driver = new WeChatDriver($request, [
-            'wechat_app_id' => 'WECHAT-APP-ID',
-            'wechat_app_key' => 'WECHAT-APP-KEY',
+            'wechat' => [
+                'app_id' => 'WECHAT-APP-ID',
+                'app_key' => 'WECHAT-APP-KEY',
+            ]
         ], $html);
 
         $message = $driver->getMessages()[0];
@@ -166,16 +165,13 @@ class WeChatDriverTest extends PHPUnit_Framework_TestCase
 </xml>';
 
         $html = m::mock(Curl::class);
-        $html->shouldReceive('post')
-            ->once()
-            ->with('https://api.wechat.com/cgi-bin/token?grant_type=client_credential&appid=WECHAT-APP-ID&secret=WECHAT-APP-KEY', [], [])
-            ->andReturn(new Response(json_encode([
-                'access_token' => 'SECRET_TOKEN',
-            ])));
+        $html->shouldReceive('post')->once()->with('https://api.wechat.com/cgi-bin/token?grant_type=client_credential&appid=WECHAT-APP-ID&secret=WECHAT-APP-KEY',
+            [], [])->andReturn(new Response(json_encode([
+            'access_token' => 'SECRET_TOKEN',
+        ])));
 
-        $html->shouldReceive('post')
-            ->once()
-            ->with('https://api.wechat.com/cgi-bin/message/custom/send?access_token=SECRET_TOKEN', [], [
+        $html->shouldReceive('post')->once()->with('https://api.wechat.com/cgi-bin/message/custom/send?access_token=SECRET_TOKEN',
+            [], [
                 'touser' => 'from_user_name',
                 'msgtype' => 'text',
                 'text' => [
@@ -186,13 +182,13 @@ class WeChatDriverTest extends PHPUnit_Framework_TestCase
         $request = m::mock(\Symfony\Component\HttpFoundation\Request::class.'[getContent]');
         $request->shouldReceive('getContent')->andReturn($xmlData);
 
-        $question = Question::create('How are you doing?')
-            ->addButton(Button::create('Great')->value('great'))
-            ->addButton(Button::create('Good')->value('good'));
+        $question = Question::create('How are you doing?')->addButton(Button::create('Great')->value('great'))->addButton(Button::create('Good')->value('good'));
 
         $driver = new WeChatDriver($request, [
-            'wechat_app_id' => 'WECHAT-APP-ID',
-            'wechat_app_key' => 'WECHAT-APP-KEY',
+            'wechat' => [
+                'app_id' => 'WECHAT-APP-ID',
+                'app_key' => 'WECHAT-APP-KEY',
+            ]
         ], $html);
 
         $message = $driver->getMessages()[0];
@@ -211,16 +207,13 @@ class WeChatDriverTest extends PHPUnit_Framework_TestCase
 </xml>';
 
         $html = m::mock(Curl::class);
-        $html->shouldReceive('post')
-            ->once()
-            ->with('https://api.wechat.com/cgi-bin/token?grant_type=client_credential&appid=WECHAT-APP-ID&secret=WECHAT-APP-KEY', [], [])
-            ->andReturn(new Response(json_encode([
-                'access_token' => 'SECRET_TOKEN',
-            ])));
+        $html->shouldReceive('post')->once()->with('https://api.wechat.com/cgi-bin/token?grant_type=client_credential&appid=WECHAT-APP-ID&secret=WECHAT-APP-KEY',
+            [], [])->andReturn(new Response(json_encode([
+            'access_token' => 'SECRET_TOKEN',
+        ])));
 
-        $html->shouldReceive('post')
-            ->once()
-            ->with('https://api.wechat.com/cgi-bin/message/custom/send?access_token=SECRET_TOKEN', [], [
+        $html->shouldReceive('post')->once()->with('https://api.wechat.com/cgi-bin/message/custom/send?access_token=SECRET_TOKEN',
+            [], [
                 'touser' => 'from_user_name',
                 'msgtype' => 'text',
                 'text' => [
@@ -231,13 +224,13 @@ class WeChatDriverTest extends PHPUnit_Framework_TestCase
         $request = m::mock(\Symfony\Component\HttpFoundation\Request::class.'[getContent]');
         $request->shouldReceive('getContent')->andReturn($xmlData);
 
-        $question = Question::create('How are you doing?')
-            ->addButton(Button::create('Great')->value('great')->additionalParameters(['foo' => 'bar']))
-            ->addButton(Button::create('Good')->value('good'));
+        $question = Question::create('How are you doing?')->addButton(Button::create('Great')->value('great')->additionalParameters(['foo' => 'bar']))->addButton(Button::create('Good')->value('good'));
 
         $driver = new WeChatDriver($request, [
-            'wechat_app_id' => 'WECHAT-APP-ID',
-            'wechat_app_key' => 'WECHAT-APP-KEY',
+            'wechat' => [
+                'app_id' => 'WECHAT-APP-ID',
+                'app_key' => 'WECHAT-APP-KEY',
+            ]
         ], $html);
 
         $message = $driver->getMessages()[0];
@@ -256,16 +249,13 @@ class WeChatDriverTest extends PHPUnit_Framework_TestCase
 </xml>';
 
         $html = m::mock(Curl::class);
-        $html->shouldReceive('post')
-            ->once()
-            ->with('https://api.wechat.com/cgi-bin/token?grant_type=client_credential&appid=WECHAT-APP-ID&secret=WECHAT-APP-KEY', [], [])
-            ->andReturn(new Response(json_encode([
-                'access_token' => 'SECRET_TOKEN',
-            ])));
+        $html->shouldReceive('post')->once()->with('https://api.wechat.com/cgi-bin/token?grant_type=client_credential&appid=WECHAT-APP-ID&secret=WECHAT-APP-KEY',
+            [], [])->andReturn(new Response(json_encode([
+            'access_token' => 'SECRET_TOKEN',
+        ])));
 
-        $html->shouldReceive('post')
-            ->once()
-            ->with('https://api.wechat.com/cgi-bin/message/custom/send?access_token=SECRET_TOKEN', [], [
+        $html->shouldReceive('post')->once()->with('https://api.wechat.com/cgi-bin/message/custom/send?access_token=SECRET_TOKEN',
+            [], [
                 'touser' => 'from_user_name',
                 'msgtype' => 'text',
                 'text' => [
@@ -278,8 +268,10 @@ class WeChatDriverTest extends PHPUnit_Framework_TestCase
         $request->shouldReceive('getContent')->andReturn($xmlData);
 
         $driver = new WeChatDriver($request, [
-            'wechat_app_id' => 'WECHAT-APP-ID',
-            'wechat_app_key' => 'WECHAT-APP-KEY',
+            'wechat' => [
+                'app_id' => 'WECHAT-APP-ID',
+                'app_key' => 'WECHAT-APP-KEY',
+            ]
         ], $html);
 
         $message = $driver->getMessages()[0];
@@ -296,15 +288,19 @@ class WeChatDriverTest extends PHPUnit_Framework_TestCase
         $htmlInterface = m::mock(Curl::class);
 
         $driver = new WeChatDriver($request, [
-            'wechat_app_id' => 'WECHAT-APP-ID',
-            'wechat_app_key' => 'WECHAT-APP-KEY',
+            'wechat' => [
+                'app_id' => 'WECHAT-APP-ID',
+                'app_key' => 'WECHAT-APP-KEY',
+            ]
         ], $htmlInterface);
 
         $this->assertTrue($driver->isConfigured());
 
         $driver = new WeChatDriver($request, [
-            'wechat_app_id' => null,
-            'wechat_app_key' => null,
+            'wechat' => [
+                'wechat_app_id' => null,
+                'wechat_app_key' => null,
+            ]
         ], $htmlInterface);
 
         $this->assertFalse($driver->isConfigured());
@@ -326,16 +322,13 @@ class WeChatDriverTest extends PHPUnit_Framework_TestCase
 </xml>';
 
         $html = m::mock(Curl::class);
-        $html->shouldReceive('post')
-            ->once()
-            ->with('https://api.wechat.com/cgi-bin/token?grant_type=client_credential&appid=WECHAT-APP-ID&secret=WECHAT-APP-KEY', [], [])
-            ->andReturn(new Response(json_encode([
-                'access_token' => 'SECRET_TOKEN',
-            ])));
+        $html->shouldReceive('post')->once()->with('https://api.wechat.com/cgi-bin/token?grant_type=client_credential&appid=WECHAT-APP-ID&secret=WECHAT-APP-KEY',
+            [], [])->andReturn(new Response(json_encode([
+            'access_token' => 'SECRET_TOKEN',
+        ])));
 
-        $html->shouldReceive('post')
-            ->once()
-            ->with('https://api.wechat.com/cgi-bin/message/custom/send?access_token=SECRET_TOKEN', [], [
+        $html->shouldReceive('post')->once()->with('https://api.wechat.com/cgi-bin/message/custom/send?access_token=SECRET_TOKEN',
+            [], [
                 'touser' => 'from_user_name',
                 'msgtype' => 'news',
                 'news' => [
@@ -352,12 +345,15 @@ class WeChatDriverTest extends PHPUnit_Framework_TestCase
         $request->shouldReceive('getContent')->andReturn($xmlData);
 
         $driver = new WeChatDriver($request, [
-            'wechat_app_id' => 'WECHAT-APP-ID',
-            'wechat_app_key' => 'WECHAT-APP-KEY',
+            'wechat' => [
+                'app_id' => 'WECHAT-APP-ID',
+                'app_key' => 'WECHAT-APP-KEY',
+            ]
         ], $html);
 
         $message = $driver->getMessages()[0];
-        $driver->sendPayload($driver->buildServicePayload(\BotMan\BotMan\Messages\Outgoing\OutgoingMessage::create('Test'), $message));
+        $driver->sendPayload($driver->buildServicePayload(\BotMan\BotMan\Messages\Outgoing\OutgoingMessage::create('Test'),
+            $message));
     }
 
     /** @test */
@@ -372,16 +368,13 @@ class WeChatDriverTest extends PHPUnit_Framework_TestCase
 </xml>';
 
         $html = m::mock(Curl::class);
-        $html->shouldReceive('post')
-            ->once()
-            ->with('https://api.wechat.com/cgi-bin/token?grant_type=client_credential&appid=WECHAT-APP-ID&secret=WECHAT-APP-KEY', [], [])
-            ->andReturn(new Response(json_encode([
-                'access_token' => 'SECRET_TOKEN',
-            ])));
+        $html->shouldReceive('post')->once()->with('https://api.wechat.com/cgi-bin/token?grant_type=client_credential&appid=WECHAT-APP-ID&secret=WECHAT-APP-KEY',
+            [], [])->andReturn(new Response(json_encode([
+            'access_token' => 'SECRET_TOKEN',
+        ])));
 
-        $html->shouldReceive('post')
-            ->once()
-            ->with('https://api.wechat.com/cgi-bin/message/custom/send?access_token=SECRET_TOKEN', [], [
+        $html->shouldReceive('post')->once()->with('https://api.wechat.com/cgi-bin/message/custom/send?access_token=SECRET_TOKEN',
+            [], [
                 'touser' => 'from_user_name',
                 'msgtype' => 'news',
                 'news' => [
@@ -398,11 +391,14 @@ class WeChatDriverTest extends PHPUnit_Framework_TestCase
         $request->shouldReceive('getContent')->andReturn($xmlData);
 
         $driver = new WeChatDriver($request, [
-            'wechat_app_id' => 'WECHAT-APP-ID',
-            'wechat_app_key' => 'WECHAT-APP-KEY',
+            'wechat' => [
+                'app_id' => 'WECHAT-APP-ID',
+                'app_key' => 'WECHAT-APP-KEY',
+            ]
         ], $html);
 
         $message = $driver->getMessages()[0];
-        $driver->sendPayload($driver->buildServicePayload(\BotMan\BotMan\Messages\Outgoing\OutgoingMessage::create('Test', Image::url('http://image.url/foo.png')), $message));
+        $driver->sendPayload($driver->buildServicePayload(\BotMan\BotMan\Messages\Outgoing\OutgoingMessage::create('Test',
+            Image::url('http://image.url/foo.png')), $message));
     }
 }

--- a/tests/WeChatVideoDriverTest.php
+++ b/tests/WeChatVideoDriverTest.php
@@ -92,8 +92,10 @@ class WeChatVideoDriverTest extends PHPUnit_Framework_TestCase
         $request->shouldReceive('getContent')->andReturn($this->validXml);
 
         $driver = new WeChatVideoDriver($request, [
-            'wechat_app_id' => 'WECHAT-APP-ID',
-            'wechat_app_key' => 'WECHAT-APP-KEY',
+            'wechat' => [
+                'app_id' => 'WECHAT-APP-ID',
+                'app_key' => 'WECHAT-APP-KEY',
+            ]
         ], $html);
 
         $messages = $driver->getMessages();
@@ -114,8 +116,10 @@ class WeChatVideoDriverTest extends PHPUnit_Framework_TestCase
         $request->shouldReceive('getContent')->andReturn($this->validXml);
 
         $driver = new WeChatVideoDriver($request, [
-            'wechat_app_id' => 'WECHAT-APP-ID',
-            'wechat_app_key' => 'WECHAT-APP-KEY',
+            'wechat' => [
+                'app_id' => 'WECHAT-APP-ID',
+                'app_key' => 'WECHAT-APP-KEY',
+            ]
         ], $html);
 
         $message = $driver->getMessages()[0];


### PR DESCRIPTION
Instead of a big botman config array there is no an array for every driver. In this PR I changed that the WeChat config data now is loaded from the wechat config array.

Tests are working but I could not test with a real wechat client, because I cannot log in to my test accoung anymore, not sure why.